### PR TITLE
feat: implement weather API domain models and GraphQL schema

### DIFF
--- a/src/main/java/com/g/b/rtd/model/Coordinates.java
+++ b/src/main/java/com/g/b/rtd/model/Coordinates.java
@@ -1,0 +1,22 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Represents geographical coordinates using latitude and longitude.
+ */
+@Data
+public class Coordinates {
+    @NotNull(message = "Latitude is required")
+    @DecimalMin(value = "-90.0", message = "Latitude must be greater than or equal to -90")
+    @DecimalMax(value = "90.0", message = "Latitude must be less than or equal to 90")
+    private Double latitude;
+
+    @NotNull(message = "Longitude is required")
+    @DecimalMin(value = "-180.0", message = "Longitude must be greater than or equal to -180")
+    @DecimalMax(value = "180.0", message = "Longitude must be less than or equal to 180")
+    private Double longitude;
+}

--- a/src/main/java/com/g/b/rtd/model/CurrentWeather.java
+++ b/src/main/java/com/g/b/rtd/model/CurrentWeather.java
@@ -1,0 +1,65 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import java.time.ZonedDateTime;
+
+/**
+ * Represents current weather conditions at a specific location.
+ */
+@Data
+public class CurrentWeather {
+    @NotNull(message = "Observation time is required")
+    private ZonedDateTime observationTime;
+
+    @Valid
+    @NotNull(message = "Temperature is required")
+    private Temperature temperature;
+
+    @Valid
+    @NotNull(message = "Wind information is required")
+    private Wind wind;
+
+    @NotBlank(message = "Weather description is required")
+    private String description;
+
+    @NotNull(message = "Relative humidity is required")
+    private Integer relativeHumidity;
+
+    private Double precipitationLastHour;
+
+    @NotNull(message = "Cloud cover percentage is required")
+    private Integer cloudCoverPercentage;
+
+    @Valid
+    @NotNull(message = "Location coordinates are required")
+    private Coordinates coordinates;
+
+    @NotBlank(message = "Station ID is required")
+    private String stationId;
+
+    private String visibility;
+
+    @NotNull(message = "Barometric pressure is required")
+    private Double barometricPressure;
+
+    private String pressureUnit;
+
+    /**
+     * Checks if precipitation was recorded in the last hour.
+     * @return true if precipitation was recorded, false otherwise
+     */
+    public boolean hasPrecipitation() {
+        return precipitationLastHour != null && precipitationLastHour > 0;
+    }
+
+    /**
+     * Determines if current conditions are considered clear.
+     * @return true if cloud cover is less than 30%, false otherwise
+     */
+    public boolean isClear() {
+        return cloudCoverPercentage < 30;
+    }
+}

--- a/src/main/java/com/g/b/rtd/model/ForecastPeriod.java
+++ b/src/main/java/com/g/b/rtd/model/ForecastPeriod.java
@@ -1,0 +1,59 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import java.time.ZonedDateTime;
+
+/**
+ * Represents a single forecast period, which can be either hourly or daily.
+ */
+@Data
+public class ForecastPeriod {
+    @NotNull(message = "Start time is required")
+    private ZonedDateTime startTime;
+
+    @NotNull(message = "End time is required")
+    private ZonedDateTime endTime;
+
+    @NotBlank(message = "Forecast description is required")
+    private String description;
+
+    @Valid
+    @NotNull(message = "Temperature information is required")
+    private Temperature temperature;
+
+    @Valid
+    @NotNull(message = "Wind information is required")
+    private Wind wind;
+
+    @NotNull(message = "Precipitation probability is required")
+    private Integer precipitationProbability;
+
+    @NotNull(message = "Relative humidity is required")
+    private Integer relativeHumidity;
+
+    private Double precipitationAmount;
+    private String precipitationUnit;
+
+    @NotNull(message = "Cloud cover percentage is required")
+    private Integer cloudCoverPercentage;
+
+    /**
+     * Checks if this is a daytime period based on the start time hour.
+     * @return true if this is a daytime period, false otherwise
+     */
+    public boolean isDaytime() {
+        int hour = startTime.getHour();
+        return hour >= 6 && hour < 20;
+    }
+
+    /**
+     * Gets the duration of this forecast period in hours.
+     * @return the duration in hours
+     */
+    public long getDurationHours() {
+        return java.time.Duration.between(startTime, endTime).toHours();
+    }
+}

--- a/src/main/java/com/g/b/rtd/model/Temperature.java
+++ b/src/main/java/com/g/b/rtd/model/Temperature.java
@@ -1,0 +1,25 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Represents a temperature measurement with its associated unit.
+ * This class handles temperature values in different scales (Fahrenheit, Celsius, Kelvin).
+ */
+@Data
+public class Temperature {
+    @NotNull(message = "Temperature value is required")
+    private Double value;
+
+    @NotNull(message = "Temperature unit is required")
+    private TemperatureUnit unit;
+
+    /**
+     * Gets the formatted temperature string including the unit symbol.
+     * @return Formatted temperature string (e.g., "72.5°F")
+     */
+    public String getFormattedTemperature() {
+        return String.format("%.1f%s", value, unit.getSymbol());
+    }
+}

--- a/src/main/java/com/g/b/rtd/model/TemperatureUnit.java
+++ b/src/main/java/com/g/b/rtd/model/TemperatureUnit.java
@@ -1,0 +1,31 @@
+package com.g.b.rtd.model;
+
+/**
+ * Enumeration of supported temperature units.
+ */
+public enum TemperatureUnit {
+    /**
+     * Fahrenheit temperature scale
+     */
+    FAHRENHEIT("°F"),
+    
+    /**
+     * Celsius temperature scale
+     */
+    CELSIUS("°C"),
+    
+    /**
+     * Kelvin temperature scale
+     */
+    KELVIN("K");
+
+    private final String symbol;
+
+    TemperatureUnit(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+}

--- a/src/main/java/com/g/b/rtd/model/WeatherAlert.java
+++ b/src/main/java/com/g/b/rtd/model/WeatherAlert.java
@@ -1,0 +1,55 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import java.time.ZonedDateTime;
+
+/**
+ * Represents a weather alert or warning issued by the National Weather Service.
+ */
+@Data
+public class WeatherAlert {
+    @NotBlank(message = "Alert ID is required")
+    private String id;
+
+    @NotBlank(message = "Alert type is required")
+    private String alertType;
+
+    @NotBlank(message = "Alert headline is required")
+    private String headline;
+
+    @NotBlank(message = "Alert description is required")
+    private String description;
+
+    @NotNull(message = "Alert severity is required")
+    private AlertSeverity severity;
+
+    @NotNull(message = "Alert start time is required")
+    private ZonedDateTime startTime;
+
+    @NotNull(message = "Alert end time is required")
+    private ZonedDateTime endTime;
+
+    private String area;
+
+    /**
+     * Enumeration of possible alert severity levels.
+     */
+    public enum AlertSeverity {
+        EXTREME,    // Extraordinary threat to life or property
+        SEVERE,     // Significant threat to life or property
+        MODERATE,   // Possible threat to life or property
+        MINOR,      // Minimal or no known threat to life or property
+        UNKNOWN     // Unknown threat level
+    }
+
+    /**
+     * Checks if the alert is currently active.
+     * @return true if the alert is currently active, false otherwise
+     */
+    public boolean isActive() {
+        ZonedDateTime now = ZonedDateTime.now();
+        return !now.isBefore(startTime) && !now.isAfter(endTime);
+    }
+}

--- a/src/main/java/com/g/b/rtd/model/WeatherForecast.java
+++ b/src/main/java/com/g/b/rtd/model/WeatherForecast.java
@@ -1,0 +1,69 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Represents a weather forecast containing multiple forecast periods.
+ * Can represent either hourly or daily forecasts.
+ */
+@Data
+public class WeatherForecast {
+    @NotNull(message = "Forecast type is required")
+    private ForecastType type;
+
+    @NotNull(message = "Generated time is required")
+    private ZonedDateTime generatedTime;
+
+    @Valid
+    @NotNull(message = "Location coordinates are required")
+    private Coordinates coordinates;
+
+    @Valid
+    @NotEmpty(message = "Forecast periods list cannot be empty")
+    private List<ForecastPeriod> periods;
+
+    @NotNull(message = "Update time is required")
+    private ZonedDateTime nextUpdate;
+
+    /**
+     * Enumeration of forecast types.
+     */
+    public enum ForecastType {
+        HOURLY,     // Hour-by-hour forecast
+        DAILY       // Day-by-day forecast
+    }
+
+    /**
+     * Gets the total forecast duration in hours.
+     * @return the total duration in hours
+     */
+    public long getTotalForecastHours() {
+        if (periods == null || periods.isEmpty()) {
+            return 0;
+        }
+        ZonedDateTime start = periods.get(0).getStartTime();
+        ZonedDateTime end = periods.get(periods.size() - 1).getEndTime();
+        return java.time.Duration.between(start, end).toHours();
+    }
+
+    /**
+     * Gets the number of forecast periods.
+     * @return the number of periods in this forecast
+     */
+    public int getNumberOfPeriods() {
+        return periods != null ? periods.size() : 0;
+    }
+
+    /**
+     * Checks if this forecast needs updating based on the nextUpdate time.
+     * @return true if the forecast needs updating, false otherwise
+     */
+    public boolean needsUpdate() {
+        return ZonedDateTime.now().isAfter(nextUpdate);
+    }
+}

--- a/src/main/java/com/g/b/rtd/model/Wind.java
+++ b/src/main/java/com/g/b/rtd/model/Wind.java
@@ -1,0 +1,42 @@
+package com.g.b.rtd.model;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Represents wind conditions including speed, direction, and gusts.
+ */
+@Data
+public class Wind {
+    @NotNull(message = "Wind speed is required")
+    @DecimalMin(value = "0.0", message = "Wind speed must be non-negative")
+    private Double speed;
+
+    @NotNull(message = "Wind direction in degrees is required")
+    @Min(value = 0, message = "Wind direction must be between 0 and 360 degrees")
+    @Max(value = 360, message = "Wind direction must be between 0 and 360 degrees")
+    private Integer directionDegrees;
+
+    @DecimalMin(value = "0.0", message = "Wind gust speed must be non-negative")
+    private Double gustSpeed;
+
+    /**
+     * Unit of measurement for wind speed (e.g., mph, km/h)
+     */
+    @NotNull(message = "Wind speed unit is required")
+    private String speedUnit;
+
+    /**
+     * Gets the cardinal direction (N, NE, E, etc.) from degrees
+     * @return Cardinal direction as a string
+     */
+    public String getCardinalDirection() {
+        String[] directions = {"N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
+                             "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"};
+        int index = (int) Math.round(((directionDegrees % 360) / 22.5));
+        return directions[index % 16];
+    }
+}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,173 @@
+"""
+Temperature information with unit
+"""
+type Temperature {
+    """
+    The numerical value of the temperature
+    """
+    value: Float!
+    
+    """
+    The unit of measurement (FAHRENHEIT, CELSIUS, KELVIN)
+    """
+    unit: String!
+    
+    """
+    Formatted temperature string including unit symbol
+    """
+    formattedTemperature: String!
+}
+
+"""
+Wind information including speed and direction
+"""
+type Wind {
+    """
+    Wind speed value
+    """
+    speed: Float!
+    
+    """
+    Wind direction in degrees (0-360)
+    """
+    directionDegrees: Int!
+    
+    """
+    Wind gust speed, if available
+    """
+    gustSpeed: Float
+    
+    """
+    Unit of measurement for wind speed
+    """
+    speedUnit: String!
+    
+    """
+    Cardinal direction (N, NE, E, etc.)
+    """
+    cardinalDirection: String!
+}
+
+"""
+Geographic coordinates
+"""
+type Coordinates {
+    """
+    Latitude in decimal degrees (-90 to 90)
+    """
+    latitude: Float!
+    
+    """
+    Longitude in decimal degrees (-180 to 180)
+    """
+    longitude: Float!
+}
+
+"""
+Current weather conditions
+"""
+type CurrentWeather {
+    observationTime: String!
+    temperature: Temperature!
+    wind: Wind!
+    description: String!
+    relativeHumidity: Int!
+    precipitationLastHour: Float
+    cloudCoverPercentage: Int!
+    coordinates: Coordinates!
+    stationId: String!
+    visibility: String
+    barometricPressure: Float!
+    pressureUnit: String!
+}
+
+"""
+Weather alert information
+"""
+type WeatherAlert {
+    id: ID!
+    alertType: String!
+    headline: String!
+    description: String!
+    severity: AlertSeverity!
+    startTime: String!
+    endTime: String!
+    area: String
+    active: Boolean!
+}
+
+"""
+Severity level of weather alerts
+"""
+enum AlertSeverity {
+    EXTREME
+    SEVERE
+    MODERATE
+    MINOR
+    UNKNOWN
+}
+
+"""
+Single forecast period (hourly or daily)
+"""
+type ForecastPeriod {
+    startTime: String!
+    endTime: String!
+    description: String!
+    temperature: Temperature!
+    wind: Wind!
+    precipitationProbability: Int!
+    relativeHumidity: Int!
+    precipitationAmount: Float
+    precipitationUnit: String
+    cloudCoverPercentage: Int!
+    isDaytime: Boolean!
+    durationHours: Int!
+}
+
+"""
+Weather forecast containing multiple periods
+"""
+type WeatherForecast {
+    type: ForecastType!
+    generatedTime: String!
+    coordinates: Coordinates!
+    periods: [ForecastPeriod!]!
+    nextUpdate: String!
+    totalForecastHours: Int!
+    numberOfPeriods: Int!
+    needsUpdate: Boolean!
+}
+
+"""
+Type of forecast (hourly or daily)
+"""
+enum ForecastType {
+    HOURLY
+    DAILY
+}
+
+"""
+Input type for coordinate-based queries
+"""
+input CoordinatesInput {
+    latitude: Float!
+    longitude: Float!
+}
+
+type Query {
+    """
+    Get current weather conditions for specified coordinates
+    """
+    currentWeather(coordinates: CoordinatesInput!): CurrentWeather!
+    
+    """
+    Get weather forecast for specified coordinates
+    """
+    forecast(coordinates: CoordinatesInput!, type: ForecastType!): WeatherForecast!
+    
+    """
+    Get active weather alerts for specified coordinates
+    """
+    activeAlerts(coordinates: CoordinatesInput!): [WeatherAlert!]!
+}


### PR DESCRIPTION
- Add core POJO classes for weather data (Temperature, Wind, Alerts, etc.)
- Create GraphQL schema with queries for current weather, forecast and alerts
- Include Jakarta validations and comprehensive documentation
- Set up temperature unit handling and coordinate validation

Files added:
- Java models: Coordinates, Temperature, Wind, WeatherAlert, etc.
- GraphQL schema with type definitions and queries
- Supporting enums and utility classes